### PR TITLE
Update ports to support TLS, add volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ The Compose template runs a message broker named `pubSubStandardSingleNode`, usi
 * port 9000 -- REST Default VPN
 * port 55555 -- SMF
 * port 2222 -- SSH connection to the Solace CLI
+* port 5671 -- AMQP Default VPN over TLS
+* port 8443 -- MQTT Default VPN over WebSockets/TLS
+* port 8883 -- MQTT Default VPN over TLS
+* port 9443 -- REST Default VPN over TLS
+* port 55003 -- SMF Compressed
+* port 55443 -- SMF over TLS
+* port 1443 -- Web Transport over TLS
+* port 1943 -- SEMP over TLS
 
 For more information about the default ports used for each service, refer to [Software Message Broker Configuration Defaults](https://docs.solace.com/Configuring-and-Managing/SW-Broker-Specific-Config/SW-Broker-Configuration-Defaults.htm).
 Once the container is created, it will take about 60 seconds for the message broker to finish activating.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The Compose template runs a message broker named `pubSubStandardSingleNode`, usi
 * port 8000 -- MQTT Default VPN over WebSockets
 * port 8080 -- SEMP / PubSub+ Manager
 * port 9000 -- REST Default VPN
-* port 55555 -- SMF
+* port 55554 -- SMF
 * port 2222 -- SSH connection to the Solace CLI
 * port 5671 -- AMQP Default VPN over TLS
 * port 8443 -- MQTT Default VPN over WebSockets/TLS

--- a/template/PubSubStandard_singleNode.yml
+++ b/template/PubSubStandard_singleNode.yml
@@ -9,7 +9,7 @@ services:
       - "storage-group:/var/lib/solace"
     shm_size: 1g
     ulimits:
-      core: 1
+      core: -1
       nofile:
         soft: 2448
         hard: 6592
@@ -30,27 +30,27 @@ services:
       #MQTT Default VPN
       - '1883:1883'
       #AMQP Default VPN over TLS
-      #- '5671:5671'
+      - '5671:5671'
       #AMQP Default VPN
       - '5672:5672'
       #MQTT Default VPN over WebSockets
       - '8000:8000'
       #MQTT Default VPN over WebSockets / TLS
-      #- '8443:8443'
+      - '8443:8443'
       #MQTT Default VPN over TLS
-      #- '8883:8883'
+      - '8883:8883'
       #SEMP / PubSub+ Manager
       - '8080:8080'
       #REST Default VPN
       - '9000:9000'
       #REST Default VPN over TLS
-      #- '9443:9443'
+      - '9443:9443'
       #SMF
       - '55554:55555'
       #SMF Compressed
-      #- '55003:55003'
+      - '55003:55003'
       #SMF over TLS
-      #- '55443:55443'
+      - '55443:55443'
       #SSH connection to CLI
       - '2222:2222'
     environment:

--- a/template/PubSubStandard_singleNode.yml
+++ b/template/PubSubStandard_singleNode.yml
@@ -5,6 +5,8 @@ services:
   primary:
     container_name: pubSubStandardSingleNode
     image: solace/solace-pubsub-standard:latest
+    volumes:
+      - "storage-group:/var/lib/solace"
     shm_size: 1g
     ulimits:
       core: 1
@@ -22,9 +24,9 @@ services:
       #Web transport
       - '8008:8008'
       #Web transport over TLS
-      #- '1443:1443'
+      - '1443:1443'
       #SEMP over TLS
-      #- '1943:1943'
+      - '1943:1943'
       #MQTT Default VPN
       - '1883:1883'
       #AMQP Default VPN over TLS
@@ -55,3 +57,6 @@ services:
       - username_admin_globalaccesslevel=admin
       - username_admin_password=admin
       - system_scaling_maxconnectioncount=100
+
+volumes:
+  storage-group:


### PR DESCRIPTION
The ports open currently are not enough to enable access to the WebUI. In order to fix this I opened the SEMP TLS port and the web traffic TLS port. 

On MacOS it was not possible to collect the container files using gather-diagnostics-host. This is due to the files being stored inside the container, instead of in a docker volume. To fix this I have added the storage-group volume, which is the volume used on the latest versions. 